### PR TITLE
feat: add solver download utilities and pipeline debugger

### DIFF
--- a/lib/BasePipelineSolver.ts
+++ b/lib/BasePipelineSolver.ts
@@ -10,12 +10,12 @@ export interface PipelineStep<T extends BaseSolver> {
 
 export function definePipelineStep<
   T extends BaseSolver,
-  P,
+  Params extends any[],
   Instance extends BasePipelineSolver<any>,
 >(
   solverName: string,
-  solverClass: new (params: P) => T,
-  getConstructorParams: (instance: Instance) => [P],
+  solverClass: new (...params: Params) => T,
+  getConstructorParams: (instance: Instance) => any[],
   opts: {
     onSolved?: (instance: Instance) => void
   } = {},

--- a/lib/react/DownloadDropdown.tsx
+++ b/lib/react/DownloadDropdown.tsx
@@ -1,0 +1,311 @@
+import React, { useEffect, useRef, useState } from "react"
+import type { BaseSolver } from "../BaseSolver"
+import { BasePipelineSolver } from "../BasePipelineSolver"
+
+export interface FileGenerationOptions {
+  solver: BaseSolver
+  params: any
+}
+
+export interface GeneratedFileDescriptor {
+  content: string
+  fileName?: string
+}
+
+export type FileGenerationResult =
+  | string
+  | GeneratedFileDescriptor
+  | null
+  | undefined
+
+export interface DownloadGenerators {
+  generatePageTsx?: (options: FileGenerationOptions) => FileGenerationResult
+  generateTestTs?: (options: FileGenerationOptions) => FileGenerationResult
+}
+
+export interface DownloadDropdownProps {
+  solver: BaseSolver
+  className?: string
+  generators?: DownloadGenerators
+}
+
+export const deepRemoveUnderscoreProperties = (obj: any): any => {
+  if (obj === null || typeof obj !== "object") {
+    return obj
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map((value) => deepRemoveUnderscoreProperties(value))
+  }
+
+  const result: Record<string, any> = {}
+  for (const [key, value] of Object.entries(obj)) {
+    if (!key.startsWith("_")) {
+      result[key] = deepRemoveUnderscoreProperties(value)
+    }
+  }
+  return result
+}
+
+const ensureDescriptor = (
+  result: FileGenerationResult,
+  fallbackFileName: string,
+): GeneratedFileDescriptor | null => {
+  if (!result) return null
+  if (typeof result === "string") {
+    return { content: result, fileName: fallbackFileName }
+  }
+  return {
+    fileName: result.fileName ?? fallbackFileName,
+    content: result.content,
+  }
+}
+
+const serializeParamsForConstructor = (
+  params: any,
+): {
+  declaration: string
+  instantiationArgs: string
+} => {
+  const serialized = JSON.stringify(params, null, 2)
+  if (Array.isArray(params)) {
+    return {
+      declaration: `const constructorParams = ${serialized} as const`,
+      instantiationArgs: "...(constructorParams as any)",
+    }
+  }
+
+  return {
+    declaration: `const inputParams = ${serialized} as const`,
+    instantiationArgs: "inputParams as any",
+  }
+}
+
+const generateDefaultPageTsx = ({
+  solver,
+  params,
+}: FileGenerationOptions): GeneratedFileDescriptor => {
+  const solverName = solver.constructor.name
+  const { declaration, instantiationArgs } =
+    serializeParamsForConstructor(params)
+
+  if (solver instanceof BasePipelineSolver) {
+    const content = `import { useMemo } from "react"
+import { PipelineDebugger } from "solver-utils/lib/react"
+import { ${solverName} } from "lib/solvers/${solverName}/${solverName}"
+
+${declaration}
+
+export default function ${solverName}PipelineDebuggerPage() {
+  const solver = useMemo(
+    () => new ${solverName}(${instantiationArgs}),
+    [],
+  )
+
+  return <PipelineDebugger solver={solver} />
+}
+`
+
+    return {
+      content,
+      fileName: `${solverName}.page.tsx`,
+    }
+  }
+
+  const content = `import { useMemo } from "react"
+import { GenericSolverDebugger } from "solver-utils/lib/react"
+import { ${solverName} } from "lib/solvers/${solverName}/${solverName}"
+
+${declaration}
+
+export default function ${solverName}DebuggerPage() {
+  const solver = useMemo(
+    () => new ${solverName}(${instantiationArgs}),
+    [],
+  )
+
+  return <GenericSolverDebugger solver={solver} />
+}
+`
+
+  return {
+    content,
+    fileName: `${solverName}.page.tsx`,
+  }
+}
+
+const generateDefaultTestTs = ({
+  solver,
+  params,
+}: FileGenerationOptions): GeneratedFileDescriptor => {
+  const solverName = solver.constructor.name
+  const { declaration, instantiationArgs } =
+    serializeParamsForConstructor(params)
+
+  const content = `import { ${solverName} } from "lib/solvers/${solverName}/${solverName}"
+import { expect, test } from "bun:test"
+
+${declaration}
+
+test("${solverName} should solve problem correctly", () => {
+  const solver = new ${solverName}(${instantiationArgs})
+  solver.solve()
+
+  expect(solver).toMatchSolverSnapshot(import.meta.path)
+
+  // Add more specific assertions based on expected output
+  // expect(solver.someProperty).toMatchInlineSnapshot()
+})
+`
+
+  return {
+    content,
+    fileName: `${solverName}.test.ts`,
+  }
+}
+
+export const DownloadDropdown = ({
+  solver,
+  className = "",
+  generators,
+}: DownloadDropdownProps) => {
+  const [isOpen, setIsOpen] = useState(false)
+  const dropdownRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false)
+      }
+    }
+
+    document.addEventListener("mousedown", handleClickOutside)
+    return () => document.removeEventListener("mousedown", handleClickOutside)
+  }, [])
+
+  const getConstructorParams = () => {
+    if (typeof solver.getConstructorParams !== "function") {
+      throw new Error(
+        `getConstructorParams() is not implemented for ${solver.constructor.name}`,
+      )
+    }
+    return deepRemoveUnderscoreProperties(solver.getConstructorParams())
+  }
+
+  const triggerDownload = (descriptor: GeneratedFileDescriptor) => {
+    if (typeof window === "undefined") return
+    const blob = new Blob([descriptor.content], { type: "text/plain" })
+    const url = window.URL.createObjectURL(blob)
+    const anchor = document.createElement("a")
+    anchor.href = url
+    anchor.download = descriptor.fileName ?? "download.txt"
+    anchor.click()
+    window.URL.revokeObjectURL(url)
+  }
+
+  const triggerJsonDownload = (fileName: string, data: any) => {
+    if (typeof window === "undefined") return
+    const blob = new Blob([JSON.stringify(data, null, 2)], {
+      type: "application/json",
+    })
+    const url = window.URL.createObjectURL(blob)
+    const anchor = document.createElement("a")
+    anchor.href = url
+    anchor.download = fileName
+    anchor.click()
+    window.URL.revokeObjectURL(url)
+  }
+
+  const handleDownloadJSON = () => {
+    try {
+      const params = getConstructorParams()
+      triggerJsonDownload(
+        `${solver.constructor.name}_params.json`,
+        params,
+      )
+    } catch (error) {
+      window.alert(
+        `Error downloading params for ${solver.constructor.name}: ${error instanceof Error ? error.message : String(error)}`,
+      )
+    }
+    setIsOpen(false)
+  }
+
+  const handleDownloadPage = () => {
+    try {
+      const params = getConstructorParams()
+      const generator = generators?.generatePageTsx ?? generateDefaultPageTsx
+      const descriptor = ensureDescriptor(
+        generator({ solver, params }),
+        `${solver.constructor.name}.page.tsx`,
+      )
+      if (!descriptor) return
+      triggerDownload(descriptor)
+    } catch (error) {
+      window.alert(
+        `Error generating page.tsx for ${solver.constructor.name}: ${error instanceof Error ? error.message : String(error)}`,
+      )
+    }
+    setIsOpen(false)
+  }
+
+  const handleDownloadTest = () => {
+    try {
+      const params = getConstructorParams()
+      const generator = generators?.generateTestTs ?? generateDefaultTestTs
+      const descriptor = ensureDescriptor(
+        generator({ solver, params }),
+        `${solver.constructor.name}.test.ts`,
+      )
+      if (!descriptor) return
+      triggerDownload(descriptor)
+    } catch (error) {
+      window.alert(
+        `Error generating test.ts for ${solver.constructor.name}: ${error instanceof Error ? error.message : String(error)}`,
+      )
+    }
+    setIsOpen(false)
+  }
+
+  return (
+    <div className={`relative ${className}`} ref={dropdownRef}>
+      <button
+        className="px-2 py-1 rounded text-xs cursor-pointer border border-gray-300 bg-white hover:bg-gray-50"
+        onClick={() => setIsOpen((open) => !open)}
+        type="button"
+        title={`Download options for ${solver.constructor.name}`}
+      >
+        {solver.constructor.name}
+      </button>
+
+      {isOpen ? (
+        <div className="absolute top-full left-0 mt-1 bg-white border border-gray-300 rounded shadow-lg z-10 min-w-[170px]">
+          <button
+            className="w-full text-left px-3 py-2 hover:bg-gray-100 text-xs"
+            onClick={handleDownloadJSON}
+            type="button"
+          >
+            Download JSON
+          </button>
+          <button
+            className="w-full text-left px-3 py-2 hover:bg-gray-100 text-xs"
+            onClick={handleDownloadPage}
+            type="button"
+          >
+            Download page.tsx
+          </button>
+          <button
+            className="w-full text-left px-3 py-2 hover:bg-gray-100 text-xs"
+            onClick={handleDownloadTest}
+            type="button"
+          >
+            Download test.ts
+          </button>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/lib/react/GenericSolverToolbar.tsx
+++ b/lib/react/GenericSolverToolbar.tsx
@@ -1,6 +1,8 @@
 import React, { useReducer, useRef, useEffect } from "react"
 import type { BaseSolver } from "../BaseSolver"
 import type { BasePipelineSolver } from "../BasePipelineSolver"
+import type { DownloadGenerators } from "./DownloadDropdown"
+import { SolverBreadcrumbInputDownloader } from "./SolverBreadcrumbInputDownloader"
 
 export interface GenericSolverToolbarProps {
   solver: BaseSolver
@@ -8,6 +10,7 @@ export interface GenericSolverToolbarProps {
   animationSpeed?: number
   onSolverStarted?: (solver: BaseSolver) => void
   onSolverCompleted?: (solver: BaseSolver) => void
+  downloadGenerators?: DownloadGenerators
 }
 
 export const GenericSolverToolbar = ({
@@ -16,6 +19,7 @@ export const GenericSolverToolbar = ({
   animationSpeed = 25,
   onSolverStarted,
   onSolverCompleted,
+  downloadGenerators,
 }: GenericSolverToolbarProps) => {
   const [isAnimating, setIsAnimating] = useReducer((x) => !x, false)
   const animationRef = useRef<NodeJS.Timeout | undefined>(undefined)
@@ -111,6 +115,10 @@ export const GenericSolverToolbar = ({
 
   return (
     <div className="space-y-2 p-2 border-b">
+      <SolverBreadcrumbInputDownloader
+        solver={solver}
+        generators={downloadGenerators}
+      />
       <div className="flex gap-2 items-center flex-wrap">
         <button
           onClick={handleStep}

--- a/lib/react/PipelineDebugger.tsx
+++ b/lib/react/PipelineDebugger.tsx
@@ -1,25 +1,27 @@
 import React, { useEffect, useMemo, useReducer } from "react"
-import type { BaseSolver } from "../BaseSolver"
 import { InteractiveGraphics } from "graphics-debug/react"
+import type { BasePipelineSolver } from "../BasePipelineSolver"
+import type { BaseSolver } from "../BaseSolver"
 import type { DownloadGenerators } from "./DownloadDropdown"
+import { PipelineStageTable } from "./PipelineStageTable"
 import { GenericSolverToolbar } from "./GenericSolverToolbar"
 
-export interface GenericSolverDebuggerProps {
-  solver: BaseSolver
+export interface PipelineDebuggerProps {
+  solver: BasePipelineSolver<any>
   animationSpeed?: number
   onSolverStarted?: (solver: BaseSolver) => void
   onSolverCompleted?: (solver: BaseSolver) => void
   downloadGenerators?: DownloadGenerators
 }
 
-export const GenericSolverDebugger = ({
+export const PipelineDebugger = ({
   solver,
-  animationSpeed = 25,
+  animationSpeed,
   onSolverStarted,
   onSolverCompleted,
   downloadGenerators,
-}: GenericSolverDebuggerProps) => {
-  const [renderCount, incRenderCount] = useReducer((x) => x + 1, 0)
+}: PipelineDebuggerProps) => {
+  const [renderCount, incRenderCount] = useReducer((x: number) => x + 1, 0)
 
   const visualization = useMemo(() => {
     try {
@@ -69,6 +71,10 @@ export const GenericSolverDebugger = ({
       ) : (
         <InteractiveGraphics graphics={visualization} />
       )}
+      <PipelineStageTable
+        pipelineSolver={solver}
+        triggerRender={incRenderCount}
+      />
     </div>
   )
 }

--- a/lib/react/PipelineStageTable.tsx
+++ b/lib/react/PipelineStageTable.tsx
@@ -1,0 +1,158 @@
+import React from "react"
+import type { BasePipelineSolver } from "../BasePipelineSolver"
+import { deepRemoveUnderscoreProperties } from "./DownloadDropdown"
+
+type StageStatus = "Solved" | "Failed" | "Running" | "Not Started"
+
+const getStageStatus = (
+  pipelineSolver: BasePipelineSolver<any>,
+  stageIndex: number,
+): StageStatus => {
+  if (pipelineSolver.currentPipelineStepIndex > stageIndex) {
+    return "Solved"
+  }
+  if (pipelineSolver.currentPipelineStepIndex === stageIndex) {
+    if (pipelineSolver.failed) return "Failed"
+    if (pipelineSolver.activeSubSolver) return "Running"
+  }
+  return "Not Started"
+}
+
+const triggerJsonDownload = (fileName: string, data: any) => {
+  if (typeof window === "undefined") return
+  const blob = new Blob([JSON.stringify(data, null, 2)], {
+    type: "application/json",
+  })
+  const url = window.URL.createObjectURL(blob)
+  const anchor = document.createElement("a")
+  anchor.href = url
+  anchor.download = fileName
+  anchor.click()
+  window.URL.revokeObjectURL(url)
+}
+
+export interface PipelineStageTableProps {
+  pipelineSolver: BasePipelineSolver<any>
+  triggerRender: () => void
+}
+
+export const PipelineStageTable = ({
+  pipelineSolver,
+  triggerRender,
+}: PipelineStageTableProps) => {
+  const handleDownloadParams = (stageName: string) => {
+    const stageDef = pipelineSolver.pipelineDef.find(
+      (stage) => stage.solverName === stageName,
+    )
+    if (!stageDef) return
+
+    try {
+      const params = deepRemoveUnderscoreProperties(
+        stageDef.getConstructorParams(pipelineSolver),
+      )
+      triggerJsonDownload(`${stageName}_params.json`, params)
+    } catch (error) {
+      window.alert(
+        `Error downloading params for ${stageName}: ${error instanceof Error ? error.message : String(error)}`,
+      )
+    }
+  }
+
+  return (
+    <div className="overflow-x-auto mt-4">
+      <table className="min-w-full border border-gray-300 text-sm">
+        <thead>
+          <tr className="bg-gray-100">
+            <th className="border border-gray-300 px-4 py-2 text-left">Stage</th>
+            <th className="border border-gray-300 px-4 py-2 text-left">
+              Status
+            </th>
+            <th className="border border-gray-300 px-4 py-2 text-left">
+              Start Iteration
+            </th>
+            <th className="border border-gray-300 px-4 py-2 text-left">
+              End Iteration
+            </th>
+            <th className="border border-gray-300 px-4 py-2 text-left">
+              Time (ms)
+            </th>
+            <th className="border border-gray-300 px-4 py-2 text-left">
+              Actions
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {pipelineSolver.pipelineDef.map((stage, index) => {
+            const status = getStageStatus(pipelineSolver, index)
+            const startIteration =
+              pipelineSolver.firstIterationOfPhase[stage.solverName]
+            const endIteration = (() => {
+              if (status !== "Solved") return undefined
+              const phaseStart =
+                pipelineSolver.firstIterationOfPhase[stage.solverName] || 0
+              const phaseSolver = (pipelineSolver as any)[stage.solverName]
+              const iterations = phaseSolver?.iterations || 0
+              return phaseStart + iterations
+            })()
+            const timeSpent = pipelineSolver.timeSpentOnPhase[stage.solverName]
+
+            return (
+              <tr key={stage.solverName} className="hover:bg-gray-50">
+                <td className="border border-gray-300 px-4 py-2 font-mono">
+                  {stage.solverName}
+                </td>
+                <td className="border border-gray-300 px-4 py-2">
+                  <div className="flex items-center gap-2">
+                    <span
+                      className={`px-2 py-1 rounded text-xs ${
+                        status === "Solved"
+                          ? "bg-green-100 text-green-800"
+                          : status === "Failed"
+                            ? "bg-red-100 text-red-800"
+                            : status === "Running"
+                              ? "bg-yellow-100 text-yellow-800"
+                              : "bg-gray-100 text-gray-800"
+                      }`}
+                    >
+                      {status}
+                    </span>
+                    <button
+                      onClick={() => {
+                        pipelineSolver.solveUntilPhase(stage.solverName)
+                        triggerRender()
+                      }}
+                      className="hover:bg-green-500 text-gray-600 hover:text-white px-2 py-1 rounded text-xs"
+                      type="button"
+                      title={`Run until ${stage.solverName} is active`}
+                    >
+                      ▶️
+                    </button>
+                  </div>
+                </td>
+                <td className="border border-gray-300 px-4 py-2 text-center">
+                  {startIteration !== undefined ? startIteration : "-"}
+                </td>
+                <td className="border border-gray-300 px-4 py-2 text-center">
+                  {endIteration !== undefined ? endIteration : "-"}
+                </td>
+                <td className="border border-gray-300 px-4 py-2 text-center">
+                  {timeSpent !== undefined ? Math.round(timeSpent) : "-"}
+                </td>
+                <td className="border border-gray-300 px-4 py-2 text-center">
+                  <button
+                    onClick={() => handleDownloadParams(stage.solverName)}
+                    className="bg-blue-500 hover:bg-blue-600 text-white px-2 py-1 rounded text-xs"
+                    type="button"
+                    title="Download constructor params"
+                  >
+                    ⬇️
+                  </button>
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/lib/react/SolverBreadcrumbInputDownloader.tsx
+++ b/lib/react/SolverBreadcrumbInputDownloader.tsx
@@ -1,0 +1,33 @@
+import React from "react"
+import type { BaseSolver } from "../BaseSolver"
+import { DownloadDropdown, type DownloadGenerators } from "./DownloadDropdown"
+
+export const getSolverChain = (solver: BaseSolver): BaseSolver[] => {
+  if (!solver.activeSubSolver) {
+    return [solver]
+  }
+  return [solver, ...getSolverChain(solver.activeSubSolver)]
+}
+
+export interface SolverBreadcrumbInputDownloaderProps {
+  solver: BaseSolver
+  generators?: DownloadGenerators
+}
+
+export const SolverBreadcrumbInputDownloader = ({
+  solver,
+  generators,
+}: SolverBreadcrumbInputDownloaderProps) => {
+  const solverChain = getSolverChain(solver)
+
+  return (
+    <div className="flex gap-1 items-center text-sm pt-1 flex-wrap">
+      {solverChain.map((solverInChain, index) => (
+        <div key={solverInChain.constructor.name} className="flex items-center">
+          {index > 0 ? <span className="text-gray-400 mx-1">→</span> : null}
+          <DownloadDropdown solver={solverInChain} generators={generators} />
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/lib/react/index.ts
+++ b/lib/react/index.ts
@@ -1,2 +1,6 @@
 export * from "./GenericSolverDebugger"
 export * from "./GenericSolverToolbar"
+export * from "./DownloadDropdown"
+export * from "./SolverBreadcrumbInputDownloader"
+export * from "./PipelineDebugger"
+export * from "./PipelineStageTable"

--- a/tests/BaseSolver.test.ts
+++ b/tests/BaseSolver.test.ts
@@ -93,7 +93,7 @@ test("BaseSolver visualization", () => {
 
 test("BaseSolver max iterations protection", () => {
   class InfiniteSolver extends BaseSolver {
-    MAX_ITERATIONS = 5
+    override MAX_ITERATIONS = 5
 
     override _step() {
       // Never set solved = true


### PR DESCRIPTION
## Summary
- add reusable download dropdown with customizable TSX/test generators and expose breadcrumb component from the toolbar
- integrate optional download generator wiring into the generic solver debugger and export new helpers
- implement a pipeline debugger with stage table support and allow pipeline steps to use multi-argument constructors while fixing related tests

## Testing
- bunx tsc --noEmit
- bun test tests
- bun run format *(fails: Script not found "format")*

------
https://chatgpt.com/codex/tasks/task_b_68cb85d2c998832ea0bb2f116d7a2e79