### PR TITLE
Add solver download utilities and pipeline debugger components

### DIFF
--- a/lib/BasePipelineSolver.ts
+++ b/lib/BasePipelineSolver.ts
@@ -10,12 +10,11 @@ export interface PipelineStep<T extends BaseSolver> {
 
 export function definePipelineStep<
   T extends BaseSolver,
-  P,
   Instance extends BasePipelineSolver<any>,
 >(
   solverName: string,
-  solverClass: new (params: P) => T,
-  getConstructorParams: (instance: Instance) => [P],
+  solverClass: new (...args: any[]) => T,
+  getConstructorParams: (instance: Instance) => any[],
   opts: {
     onSolved?: (instance: Instance) => void
   } = {},

--- a/lib/react/DownloadDropdown.tsx
+++ b/lib/react/DownloadDropdown.tsx
@@ -1,0 +1,237 @@
+import React, { useEffect, useRef, useState } from "react"
+import type { BaseSolver } from "../BaseSolver"
+import {
+  getConstructorParamsSafely,
+  stringifyForDownload,
+  triggerDownload,
+} from "./solverDownloadUtils"
+import {
+  resolvePageDownloadConfig,
+  resolveTestDownloadConfig,
+} from "./solverDownloadOverrides"
+
+export interface DownloadDropdownProps {
+  solver: BaseSolver
+  className?: string
+}
+
+interface ConstructorParamMetadata {
+  variableName: string
+  serializedValue: string
+  isArray: boolean
+}
+
+const getConstructorParamMetadata = (
+  constructorParams: unknown,
+): ConstructorParamMetadata => {
+  const isArray = Array.isArray(constructorParams)
+  return {
+    variableName: isArray ? "constructorArgs" : "inputProblem",
+    serializedValue: stringifyForDownload(constructorParams),
+    isArray,
+  }
+}
+
+const buildInstantiationSnippet = (
+  solverName: string,
+  metadata: ConstructorParamMetadata,
+) => {
+  if (metadata.isArray) {
+    return `new ${solverName}(...${metadata.variableName} as any[])`
+  }
+  return `new ${solverName}(${metadata.variableName} as any)`
+}
+
+const buildDefaultPageContent = (
+  solver: BaseSolver,
+  constructorParams: unknown,
+) => {
+  const solverName = solver.constructor.name
+  const isPipelineSolver =
+    solverName === "SchematicTracePipelineSolver" ||
+    typeof (solver as any).pipelineDef !== "undefined"
+
+  const paramMetadata = getConstructorParamMetadata(constructorParams)
+  const declaration = `const ${paramMetadata.variableName} = ${paramMetadata.serializedValue}`
+  const instantiation = buildInstantiationSnippet(solverName, paramMetadata)
+
+  if (isPipelineSolver) {
+    return `import { useMemo } from "react"
+import { PipelineDebugger } from "@tscircuit/solver-utils/lib/react"
+import { ${solverName} } from "lib/solvers/${solverName}/${solverName}"
+
+export ${declaration}
+
+export default () => {
+  const solver = useMemo(() => {
+    return ${instantiation}
+  }, [])
+  return <PipelineDebugger solver={solver} />
+}
+`
+  }
+
+  return `import { useMemo } from "react"
+import { GenericSolverDebugger } from "@tscircuit/solver-utils/lib/react"
+import { ${solverName} } from "lib/solvers/${solverName}/${solverName}"
+
+export ${declaration}
+
+export default () => {
+  const solver = useMemo(() => {
+    return ${instantiation}
+  }, [])
+  return <GenericSolverDebugger solver={solver} />
+}
+`
+}
+
+const buildDefaultTestContent = (
+  solver: BaseSolver,
+  constructorParams: unknown,
+) => {
+  const solverName = solver.constructor.name
+  const paramMetadata = getConstructorParamMetadata(constructorParams)
+  const declaration = `const ${paramMetadata.variableName} = ${paramMetadata.serializedValue}`
+  const instantiation = buildInstantiationSnippet(solverName, paramMetadata)
+  return `import { ${solverName} } from "lib/solvers/${solverName}/${solverName}"
+import { expect, test } from "bun:test"
+
+test("${solverName} should solve problem correctly", () => {
+  ${declaration}
+
+  const solver = ${instantiation}
+  solver.solve()
+
+  expect(solver).toMatchSolverSnapshot(import.meta.path)
+
+  // Add more specific assertions based on expected output
+  // expect(solver.netLabelPlacementSolver!.netLabelPlacements).toMatchInlineSnapshot()
+})
+`
+}
+
+export const DownloadDropdown = ({
+  solver,
+  className = "",
+}: DownloadDropdownProps) => {
+  const [isOpen, setIsOpen] = useState(false)
+  const dropdownRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (typeof document === "undefined") {
+      return
+    }
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false)
+      }
+    }
+
+    document.addEventListener("mousedown", handleClickOutside)
+    return () => document.removeEventListener("mousedown", handleClickOutside)
+  }, [])
+
+  const closeDropdown = () => setIsOpen(false)
+
+  const downloadJSON = () => {
+    const params = getConstructorParamsSafely(solver)
+    if (!params) {
+      closeDropdown()
+      return
+    }
+
+    triggerDownload(
+      `${solver.constructor.name}_params.json`,
+      stringifyForDownload(params.sanitized),
+      "application/json",
+    )
+    closeDropdown()
+  }
+
+  const downloadPageTsx = () => {
+    const params = getConstructorParamsSafely(solver)
+    if (!params) {
+      closeDropdown()
+      return
+    }
+
+    const defaultContent = buildDefaultPageContent(solver, params.sanitized)
+    const { filename, contents } = resolvePageDownloadConfig({
+      solver,
+      constructorParams: params.sanitized,
+      rawConstructorParams: params.raw,
+      defaultFilename: `${solver.constructor.name}.page.tsx`,
+      defaultContents: defaultContent,
+    })
+
+    triggerDownload(filename, contents)
+    closeDropdown()
+  }
+
+  const downloadTestTs = () => {
+    const params = getConstructorParamsSafely(solver)
+    if (!params) {
+      closeDropdown()
+      return
+    }
+
+    const defaultContent = buildDefaultTestContent(
+      solver,
+      params.sanitized,
+    )
+    const { filename, contents } = resolveTestDownloadConfig({
+      solver,
+      constructorParams: params.sanitized,
+      rawConstructorParams: params.raw,
+      defaultFilename: `${solver.constructor.name}.test.ts`,
+      defaultContents: defaultContent,
+    })
+
+    triggerDownload(filename, contents)
+    closeDropdown()
+  }
+
+  return (
+    <div className={`relative ${className}`} ref={dropdownRef}>
+      <button
+        className="px-2 py-1 rounded text-xs cursor-pointer border border-gray-200 hover:bg-gray-50 bg-white"
+        onClick={() => setIsOpen((prev) => !prev)}
+        title={`Download options for ${solver.constructor.name}`}
+        type="button"
+      >
+        {solver.constructor.name}
+      </button>
+
+      {isOpen ? (
+        <div className="absolute top-full left-0 mt-1 bg-white border border-gray-200 rounded shadow-lg z-10 min-w-[170px]">
+          <button
+            className="w-full text-left px-3 py-2 hover:bg-gray-100 text-xs"
+            onClick={downloadJSON}
+            type="button"
+          >
+            Download JSON
+          </button>
+          <button
+            className="w-full text-left px-3 py-2 hover:bg-gray-100 text-xs"
+            onClick={downloadPageTsx}
+            type="button"
+          >
+            Download page.tsx
+          </button>
+          <button
+            className="w-full text-left px-3 py-2 hover:bg-gray-100 text-xs"
+            onClick={downloadTestTs}
+            type="button"
+          >
+            Download test.ts
+          </button>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/lib/react/GenericSolverDebugger.tsx
+++ b/lib/react/GenericSolverDebugger.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useReducer } from "react"
+import type { ReactNode } from "react"
 import type { BaseSolver } from "../BaseSolver"
 import { InteractiveGraphics } from "graphics-debug/react"
 import { GenericSolverToolbar } from "./GenericSolverToolbar"
@@ -8,6 +9,10 @@ export interface GenericSolverDebuggerProps {
   animationSpeed?: number
   onSolverStarted?: (solver: BaseSolver) => void
   onSolverCompleted?: (solver: BaseSolver) => void
+  renderBelowVisualizer?: (args: {
+    solver: BaseSolver
+    triggerRender: () => void
+  }) => ReactNode
 }
 
 export const GenericSolverDebugger = ({
@@ -15,6 +20,7 @@ export const GenericSolverDebugger = ({
   animationSpeed = 25,
   onSolverStarted,
   onSolverCompleted,
+  renderBelowVisualizer,
 }: GenericSolverDebuggerProps) => {
   const [renderCount, incRenderCount] = useReducer((x) => x + 1, 0)
 
@@ -65,6 +71,7 @@ export const GenericSolverDebugger = ({
       ) : (
         <InteractiveGraphics graphics={visualization} />
       )}
+      {renderBelowVisualizer?.({ solver, triggerRender: incRenderCount })}
     </div>
   )
 }

--- a/lib/react/GenericSolverToolbar.tsx
+++ b/lib/react/GenericSolverToolbar.tsx
@@ -1,6 +1,7 @@
 import React, { useReducer, useRef, useEffect } from "react"
 import type { BaseSolver } from "../BaseSolver"
 import type { BasePipelineSolver } from "../BasePipelineSolver"
+import { SolverBreadcrumbInputDownloader } from "./SolverBreadcrumbInputDownloader"
 
 export interface GenericSolverToolbarProps {
   solver: BaseSolver
@@ -111,6 +112,8 @@ export const GenericSolverToolbar = ({
 
   return (
     <div className="space-y-2 p-2 border-b">
+      <SolverBreadcrumbInputDownloader solver={solver} />
+
       <div className="flex gap-2 items-center flex-wrap">
         <button
           onClick={handleStep}

--- a/lib/react/PipelineDebugger.tsx
+++ b/lib/react/PipelineDebugger.tsx
@@ -1,0 +1,94 @@
+import React, { useRef } from "react"
+import type { BasePipelineSolver } from "../BasePipelineSolver"
+import type { BaseSolver } from "../BaseSolver"
+import { GenericSolverDebugger } from "./GenericSolverDebugger"
+import { PipelineStageTable } from "./PipelineStageTable"
+
+interface PipelineDebuggerBaseProps<TSolver extends BasePipelineSolver<any>> {
+  animationSpeed?: number
+  onSolverStarted?: (solver: TSolver) => void
+  onSolverCompleted?: (solver: TSolver) => void
+}
+
+interface PipelineDebuggerWithSolver<TSolver extends BasePipelineSolver<any>>
+  extends PipelineDebuggerBaseProps<TSolver> {
+  solver: TSolver
+}
+
+interface PipelineDebuggerWithFactory<
+  TInput,
+  TSolver extends BasePipelineSolver<TInput>,
+> extends PipelineDebuggerBaseProps<TSolver> {
+  inputProblem: TInput
+  createSolver: (input: TInput) => TSolver
+}
+
+export type PipelineDebuggerProps<
+  TInput,
+  TSolver extends BasePipelineSolver<TInput>,
+> = PipelineDebuggerWithSolver<TSolver> | PipelineDebuggerWithFactory<TInput, TSolver>
+
+const usePipelineSolverInstance = <
+  TInput,
+  TSolver extends BasePipelineSolver<TInput>,
+>(props: PipelineDebuggerProps<TInput, TSolver>): TSolver => {
+  const solverRef = useRef<TSolver | null>(null)
+  const lastInputRef = useRef<TInput | null>(null)
+  const lastFactoryRef = useRef<((input: TInput) => TSolver) | null>(null)
+
+  if ("solver" in props) {
+    if (solverRef.current !== props.solver) {
+      solverRef.current = props.solver
+    }
+  } else {
+    if (
+      !solverRef.current ||
+      lastInputRef.current !== props.inputProblem ||
+      lastFactoryRef.current !== props.createSolver
+    ) {
+      solverRef.current = props.createSolver(props.inputProblem)
+      lastInputRef.current = props.inputProblem
+      lastFactoryRef.current = props.createSolver
+    }
+  }
+
+  if (!solverRef.current) {
+    throw new Error("PipelineDebugger failed to initialize a solver instance")
+  }
+
+  return solverRef.current
+}
+
+export const PipelineDebugger = <
+  TInput,
+  TSolver extends BasePipelineSolver<TInput>,
+>(
+  props: PipelineDebuggerProps<TInput, TSolver>,
+) => {
+  const solver = usePipelineSolverInstance(props)
+
+  const { animationSpeed, onSolverStarted, onSolverCompleted } = props
+
+  const handleSolverStarted = onSolverStarted
+    ? (baseSolver: BaseSolver) => onSolverStarted(baseSolver as TSolver)
+    : undefined
+
+  const handleSolverCompleted = onSolverCompleted
+    ? (baseSolver: BaseSolver) => onSolverCompleted(baseSolver as TSolver)
+    : undefined
+
+  return (
+    <GenericSolverDebugger
+      solver={solver}
+      animationSpeed={animationSpeed}
+      onSolverStarted={handleSolverStarted}
+      onSolverCompleted={handleSolverCompleted}
+      renderBelowVisualizer={({ triggerRender }) => (
+        <PipelineStageTable
+          pipelineSolver={solver}
+          triggerRender={triggerRender}
+        />
+      )}
+    />
+  )
+}

--- a/lib/react/PipelineStageTable.tsx
+++ b/lib/react/PipelineStageTable.tsx
@@ -1,0 +1,153 @@
+import React from "react"
+import type { BasePipelineSolver } from "../BasePipelineSolver"
+import {
+  sanitizeConstructorParams,
+  stringifyForDownload,
+  triggerDownload,
+} from "./solverDownloadUtils"
+
+type StageStatus = "Solved" | "Failed" | "Running" | "Not Started"
+
+export interface PipelineStageTableProps {
+  pipelineSolver: BasePipelineSolver<any>
+  triggerRender: () => void
+}
+
+const determineStageStatus = (
+  pipelineSolver: BasePipelineSolver<any>,
+  stageIndex: number,
+): StageStatus => {
+  if (pipelineSolver.currentPipelineStepIndex > stageIndex) {
+    return "Solved"
+  }
+  if (pipelineSolver.currentPipelineStepIndex === stageIndex) {
+    if (pipelineSolver.failed) return "Failed"
+    if (pipelineSolver.activeSubSolver) return "Running"
+  }
+  return "Not Started"
+}
+
+const downloadStageParams = (
+  pipelineSolver: BasePipelineSolver<any>,
+  stageName: string,
+) => {
+  const stage = pipelineSolver.pipelineDef.find(
+    (step) => step.solverName === stageName,
+  )
+
+  if (!stage) {
+    return
+  }
+
+  try {
+    const params = stage.getConstructorParams(pipelineSolver)
+    const sanitized = sanitizeConstructorParams(params)
+    triggerDownload(
+      `${stageName}_params.json`,
+      stringifyForDownload(sanitized),
+      "application/json",
+    )
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : `Unknown error: ${String(error)}`
+    const fullMessage = `Error downloading params for ${stageName}: ${message}`
+    console.error(fullMessage)
+    if (typeof window !== "undefined" && typeof window.alert === "function") {
+      window.alert(fullMessage)
+    }
+  }
+}
+
+export const PipelineStageTable = ({
+  pipelineSolver,
+  triggerRender,
+}: PipelineStageTableProps) => {
+  return (
+    <div className="overflow-x-auto mt-4">
+      <table className="min-w-full border border-gray-300 text-sm">
+        <thead>
+          <tr className="bg-gray-100">
+            <th className="border border-gray-300 px-4 py-2 text-left">Stage</th>
+            <th className="border border-gray-300 px-4 py-2 text-left">Status</th>
+            <th className="border border-gray-300 px-4 py-2 text-left">
+              Start Iteration
+            </th>
+            <th className="border border-gray-300 px-4 py-2 text-left">
+              End Iteration
+            </th>
+            <th className="border border-gray-300 px-4 py-2 text-left">Time (ms)</th>
+            <th className="border border-gray-300 px-4 py-2 text-left">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {pipelineSolver.pipelineDef.map((stage, index) => {
+            const status = determineStageStatus(pipelineSolver, index)
+            const startIteration =
+              pipelineSolver.firstIterationOfPhase[stage.solverName]
+            const endIteration =
+              status === "Solved"
+                ? (pipelineSolver.firstIterationOfPhase[stage.solverName] || 0) +
+                  ((pipelineSolver as any)[stage.solverName]?.iterations || 0)
+                : undefined
+            const timeSpent = pipelineSolver.timeSpentOnPhase[stage.solverName]
+
+            return (
+              <tr key={stage.solverName} className="hover:bg-gray-50">
+                <td className="border border-gray-300 px-4 py-2 font-mono text-xs">
+                  {stage.solverName}
+                </td>
+                <td className="border border-gray-300 px-4 py-2">
+                  <div className="flex items-center gap-2">
+                    <span
+                      className={`px-2 py-1 rounded text-xs ${
+                        status === "Solved"
+                          ? "bg-green-100 text-green-800"
+                          : status === "Failed"
+                            ? "bg-red-100 text-red-800"
+                            : status === "Running"
+                              ? "bg-yellow-100 text-yellow-800"
+                              : "bg-gray-100 text-gray-800"
+                      }`}
+                    >
+                      {status}
+                    </span>
+                    <button
+                      onClick={() => {
+                        pipelineSolver.solveUntilPhase(stage.solverName)
+                        triggerRender()
+                      }}
+                      className="hover:bg-green-500 text-gray-600 hover:text-white px-2 py-1 rounded text-xs"
+                      title={`Run until ${stage.solverName} is active`}
+                      type="button"
+                    >
+                      ▶️
+                    </button>
+                  </div>
+                </td>
+                <td className="border border-gray-300 px-4 py-2 text-center">
+                  {startIteration !== undefined ? startIteration : "-"}
+                </td>
+                <td className="border border-gray-300 px-4 py-2 text-center">
+                  {endIteration !== undefined ? endIteration : "-"}
+                </td>
+                <td className="border border-gray-300 px-4 py-2 text-center">
+                  {timeSpent !== undefined ? Math.round(timeSpent) : "-"}
+                </td>
+                <td className="border border-gray-300 px-4 py-2 text-center">
+                  <button
+                    onClick={() => downloadStageParams(pipelineSolver, stage.solverName)}
+                    className="bg-blue-500 hover:bg-blue-600 text-white px-2 py-1 rounded text-xs"
+                    title="Download constructor params"
+                    type="button"
+                  >
+                    ⬇️
+                  </button>
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/lib/react/SolverBreadcrumbInputDownloader.tsx
+++ b/lib/react/SolverBreadcrumbInputDownloader.tsx
@@ -1,0 +1,40 @@
+import React from "react"
+import type { BaseSolver } from "../BaseSolver"
+import { DownloadDropdown } from "./DownloadDropdown"
+
+export const getSolverChain = (solver: BaseSolver): BaseSolver[] => {
+  const chain: BaseSolver[] = []
+  const visited = new Set<BaseSolver>()
+  let current: BaseSolver | null | undefined = solver
+
+  while (current && !visited.has(current)) {
+    chain.push(current)
+    visited.add(current)
+    current = current.activeSubSolver ?? undefined
+  }
+
+  return chain
+}
+
+export interface SolverBreadcrumbInputDownloaderProps {
+  solver: BaseSolver
+  className?: string
+}
+
+export const SolverBreadcrumbInputDownloader = ({
+  solver,
+  className = "",
+}: SolverBreadcrumbInputDownloaderProps) => {
+  const solverChain = getSolverChain(solver)
+
+  return (
+    <div className={`flex flex-wrap gap-2 items-center text-xs text-gray-600 ${className}`}>
+      {solverChain.map((chainSolver, index) => (
+        <div key={`${chainSolver.constructor.name}-${index}`} className="flex items-center gap-1">
+          {index > 0 ? <span className="text-gray-400">→</span> : null}
+          <DownloadDropdown solver={chainSolver} />
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/lib/react/index.ts
+++ b/lib/react/index.ts
@@ -1,2 +1,7 @@
 export * from "./GenericSolverDebugger"
 export * from "./GenericSolverToolbar"
+export * from "./DownloadDropdown"
+export * from "./PipelineDebugger"
+export * from "./PipelineStageTable"
+export * from "./SolverBreadcrumbInputDownloader"
+export * from "./solverDownloadOverrides"

--- a/lib/react/solverDownloadOverrides.ts
+++ b/lib/react/solverDownloadOverrides.ts
@@ -1,0 +1,70 @@
+import type { BaseSolver } from "../BaseSolver"
+
+export interface DownloadGeneratorOptions<TSolver extends BaseSolver = BaseSolver> {
+  solver: TSolver
+  constructorParams: unknown
+  rawConstructorParams: unknown
+  defaultFilename: string
+  defaultContents: string
+}
+
+export interface DownloadGeneratorResult {
+  filename?: string
+  contents?: string
+}
+
+export type DownloadGenerator<TSolver extends BaseSolver = BaseSolver> = (
+  options: DownloadGeneratorOptions<TSolver>,
+) => DownloadGeneratorResult | void | null | undefined
+
+let pageGeneratorOverride: DownloadGenerator | null = null
+let testGeneratorOverride: DownloadGenerator | null = null
+
+const applyOverride = (
+  override: DownloadGenerator | null,
+  options: DownloadGeneratorOptions,
+): { filename: string; contents: string } => {
+  const resolved = {
+    filename: options.defaultFilename,
+    contents: options.defaultContents,
+  }
+
+  if (!override) {
+    return resolved
+  }
+
+  const result = override(options)
+  if (!result) {
+    return resolved
+  }
+
+  return {
+    filename: result.filename ?? resolved.filename,
+    contents: result.contents ?? resolved.contents,
+  }
+}
+
+export const setSolverPageDownloadGenerator = (
+  generator?: DownloadGenerator | null,
+) => {
+  pageGeneratorOverride = generator ?? null
+}
+
+export const setSolverTestDownloadGenerator = (
+  generator?: DownloadGenerator | null,
+) => {
+  testGeneratorOverride = generator ?? null
+}
+
+export const resetSolverDownloadGenerators = () => {
+  pageGeneratorOverride = null
+  testGeneratorOverride = null
+}
+
+export const resolvePageDownloadConfig = (
+  options: DownloadGeneratorOptions,
+): { filename: string; contents: string } => applyOverride(pageGeneratorOverride, options)
+
+export const resolveTestDownloadConfig = (
+  options: DownloadGeneratorOptions,
+): { filename: string; contents: string } => applyOverride(testGeneratorOverride, options)

--- a/lib/react/solverDownloadUtils.ts
+++ b/lib/react/solverDownloadUtils.ts
@@ -1,0 +1,81 @@
+import type { BaseSolver } from "../BaseSolver"
+
+export const deepRemoveUnderscoreProperties = (obj: unknown): unknown => {
+  if (obj === null || typeof obj !== "object") {
+    return obj
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map(deepRemoveUnderscoreProperties)
+  }
+
+  const result: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
+    if (!key.startsWith("_")) {
+      result[key] = deepRemoveUnderscoreProperties(value)
+    }
+  }
+  return result
+}
+
+export const sanitizeConstructorParams = (params: unknown): unknown =>
+  deepRemoveUnderscoreProperties(params)
+
+export const stringifyForDownload = (value: unknown): string =>
+  JSON.stringify(value, null, 2)
+
+export const triggerDownload = (
+  filename: string,
+  contents: string,
+  mimeType = "text/plain",
+) => {
+  if (
+    typeof window === "undefined" ||
+    typeof document === "undefined" ||
+    typeof Blob === "undefined"
+  ) {
+    console.warn(
+      `Download attempted for "${filename}" in a non-browser environment.`,
+    )
+    return
+  }
+
+  try {
+    const blob = new Blob([contents], { type: mimeType })
+    const url = URL.createObjectURL(blob)
+    const anchor = document.createElement("a")
+    anchor.href = url
+    anchor.download = filename
+    document.body.appendChild(anchor)
+    anchor.click()
+    document.body.removeChild(anchor)
+    URL.revokeObjectURL(url)
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : `Unknown error: ${String(error)}`
+    console.error(`Failed to download ${filename}: ${message}`)
+    if (typeof window !== "undefined" && typeof window.alert === "function") {
+      window.alert(`Failed to download ${filename}: ${message}`)
+    }
+  }
+}
+
+export const getConstructorParamsSafely = (
+  solver: BaseSolver,
+): { sanitized: unknown; raw: unknown } | null => {
+  try {
+    const rawParams = solver.getConstructorParams()
+    const sanitized = sanitizeConstructorParams(rawParams)
+    return { raw: rawParams, sanitized }
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : `Unknown error: ${String(error)}`
+    const solverName = solver.constructor.name
+    const fullMessage = `Unable to retrieve constructor params for ${solverName}: ${message}`
+    console.error(fullMessage)
+    if (typeof window !== "undefined" && typeof window.alert === "function") {
+      window.alert(fullMessage)
+    }
+    return null
+  }
+}

--- a/tests/BaseSolver.test.ts
+++ b/tests/BaseSolver.test.ts
@@ -93,7 +93,7 @@ test("BaseSolver visualization", () => {
 
 test("BaseSolver max iterations protection", () => {
   class InfiniteSolver extends BaseSolver {
-    MAX_ITERATIONS = 5
+    override MAX_ITERATIONS = 5
 
     override _step() {
       // Never set solved = true

--- a/tests/DownloadOverrides.test.ts
+++ b/tests/DownloadOverrides.test.ts
@@ -1,0 +1,111 @@
+import { expect, test, describe, afterEach } from "bun:test"
+import { BaseSolver } from "../lib/BaseSolver"
+import {
+  resolvePageDownloadConfig,
+  resolveTestDownloadConfig,
+  resetSolverDownloadGenerators,
+  setSolverPageDownloadGenerator,
+  setSolverTestDownloadGenerator,
+} from "../lib/react/solverDownloadOverrides"
+import { sanitizeConstructorParams } from "../lib/react/solverDownloadUtils"
+
+describe("solver download overrides", () => {
+  afterEach(() => {
+    resetSolverDownloadGenerators()
+  })
+
+  class DemoSolver extends BaseSolver {
+    constructor(private readonly params: Record<string, unknown>) {
+      super()
+    }
+
+    override _step() {}
+
+    override getConstructorParams() {
+      return this.params
+    }
+  }
+
+  const createSolver = () =>
+    new DemoSolver({
+      publicValue: 42,
+      _private: "ignore-me",
+      nested: { value: 10, _secret: true },
+    })
+
+  test("uses default filenames and contents when no override is set", () => {
+    const solver = createSolver()
+    const raw = solver.getConstructorParams()
+    const sanitized = sanitizeConstructorParams(raw)
+
+    const pageConfig = resolvePageDownloadConfig({
+      solver,
+      constructorParams: sanitized,
+      rawConstructorParams: raw,
+      defaultFilename: "DemoSolver.page.tsx",
+      defaultContents: "// default page",
+    })
+
+    expect(pageConfig).toEqual({
+      filename: "DemoSolver.page.tsx",
+      contents: "// default page",
+    })
+
+    const testConfig = resolveTestDownloadConfig({
+      solver,
+      constructorParams: sanitized,
+      rawConstructorParams: raw,
+      defaultFilename: "DemoSolver.test.ts",
+      defaultContents: "// default test",
+    })
+
+    expect(testConfig).toEqual({
+      filename: "DemoSolver.test.ts",
+      contents: "// default test",
+    })
+  })
+
+  test("allows overrides to customize filename and contents", () => {
+    const solver = createSolver()
+    const raw = solver.getConstructorParams()
+    const sanitized = sanitizeConstructorParams(raw)
+
+    setSolverPageDownloadGenerator(({ defaultFilename }) => ({
+      filename: defaultFilename.replace("DemoSolver", "CustomSolver"),
+      contents: "// overridden page",
+    }))
+
+    setSolverTestDownloadGenerator(({ constructorParams }) => ({
+      contents: JSON.stringify(constructorParams),
+    }))
+
+    const pageConfig = resolvePageDownloadConfig({
+      solver,
+      constructorParams: sanitized,
+      rawConstructorParams: raw,
+      defaultFilename: "DemoSolver.page.tsx",
+      defaultContents: "// default page",
+    })
+
+    expect(pageConfig).toEqual({
+      filename: "CustomSolver.page.tsx",
+      contents: "// overridden page",
+    })
+
+    const testConfig = resolveTestDownloadConfig({
+      solver,
+      constructorParams: sanitized,
+      rawConstructorParams: raw,
+      defaultFilename: "DemoSolver.test.ts",
+      defaultContents: "// default test",
+    })
+
+    expect(testConfig).toEqual({
+      filename: "DemoSolver.test.ts",
+      contents: JSON.stringify({
+        publicValue: 42,
+        nested: { value: 10 },
+      }),
+    })
+  })
+})

--- a/tests/SolverBreadcrumbInputDownloader.test.ts
+++ b/tests/SolverBreadcrumbInputDownloader.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test"
+import { BaseSolver } from "../lib/BaseSolver"
+import { getSolverChain } from "../lib/react/SolverBreadcrumbInputDownloader"
+
+class ChainSolver extends BaseSolver {
+  override _step() {}
+
+  override getConstructorParams() {
+    return {}
+  }
+}
+
+describe("getSolverChain", () => {
+  test("returns the chain of active sub solvers", () => {
+    const rootSolver = new ChainSolver()
+    const childSolver = new ChainSolver()
+    const grandChildSolver = new ChainSolver()
+
+    rootSolver.activeSubSolver = childSolver
+    childSolver.activeSubSolver = grandChildSolver
+
+    const chain = getSolverChain(rootSolver)
+    expect(chain).toEqual([rootSolver, childSolver, grandChildSolver])
+  })
+
+  test("guards against circular references", () => {
+    const solverA = new ChainSolver()
+    const solverB = new ChainSolver()
+
+    solverA.activeSubSolver = solverB
+    solverB.activeSubSolver = solverA
+
+    const chain = getSolverChain(solverA)
+    expect(chain).toEqual([solverA, solverB])
+  })
+})


### PR DESCRIPTION
## Summary
- add a solver download dropdown with JSON/page/test exports and breadcrumb navigation
- expose override hooks so consumers can customize generated page.tsx and test.ts content
- introduce pipeline debugger and stage table React components backed by reusable download utilities
- update pipeline helper typing to support multi-argument constructor params and add targeted tests

## Testing
- bunx tsc --noEmit
- bun test

------
https://chatgpt.com/codex/tasks/task_b_68cb85d2c998832ea0bb2f116d7a2e79