### PR TITLE
Add solver download utilities and pipeline debugger

### DIFF
--- a/lib/BasePipelineSolver.ts
+++ b/lib/BasePipelineSolver.ts
@@ -1,10 +1,13 @@
 import type { GraphicsObject } from "graphics-debug"
 import { BaseSolver } from "./BaseSolver"
 
-export interface PipelineStep<T extends BaseSolver> {
+export interface PipelineStep<
+  T extends BaseSolver = BaseSolver,
+  P = any,
+> {
   solverName: string
-  solverClass: new (...args: any[]) => T
-  getConstructorParams: (pipelineInstance: any) => any[]
+  solverClass: new (params: P) => T
+  getConstructorParams: (pipelineInstance: any) => P
   onSolved?: (pipelineInstance: any) => void
 }
 
@@ -15,11 +18,11 @@ export function definePipelineStep<
 >(
   solverName: string,
   solverClass: new (params: P) => T,
-  getConstructorParams: (instance: Instance) => [P],
+  getConstructorParams: (instance: Instance) => P,
   opts: {
     onSolved?: (instance: Instance) => void
   } = {},
-): PipelineStep<T> {
+): PipelineStep<T, P> {
   return {
     solverName,
     solverClass,
@@ -40,7 +43,7 @@ export abstract class BasePipelineSolver<TInput> extends BaseSolver {
   /** Stores the outputs from each completed pipeline step */
   pipelineOutputs: Record<string, any> = {}
 
-  abstract pipelineDef: PipelineStep<any>[]
+  abstract pipelineDef: PipelineStep<any, any>[]
 
   constructor(inputProblem: TInput) {
     super()
@@ -81,7 +84,7 @@ export abstract class BasePipelineSolver<TInput> extends BaseSolver {
     }
 
     const constructorParams = pipelineStepDef.getConstructorParams(this)
-    this.activeSubSolver = new pipelineStepDef.solverClass(...constructorParams)
+    this.activeSubSolver = new pipelineStepDef.solverClass(constructorParams)
     ;(this as any)[pipelineStepDef.solverName] = this.activeSubSolver
     this.timeSpentOnPhase[pipelineStepDef.solverName] = 0
     this.startTimeOfPhase[pipelineStepDef.solverName] = performance.now()

--- a/lib/BaseSolver.ts
+++ b/lib/BaseSolver.ts
@@ -8,8 +8,9 @@ import type { GraphicsObject } from "graphics-debug"
  * Solvers should override visualize() to return a GraphicsObject representing
  * the current state of the solver.
  *
- * Solvers should override getConstructorParams() to return the parameters
- * needed to construct the solver.
+ * Solvers should override getConstructorParams() to return the object passed as
+ * the first (and only) constructor parameter. This keeps constructor
+ * signatures serializable for tooling like the download dropdowns.
  */
 export class BaseSolver {
   MAX_ITERATIONS = 100e3

--- a/lib/react/DownloadDropdown.tsx
+++ b/lib/react/DownloadDropdown.tsx
@@ -1,0 +1,254 @@
+import React, { useEffect, useRef, useState } from "react"
+import type { BaseSolver } from "../BaseSolver"
+import { BasePipelineSolver } from "../BasePipelineSolver"
+
+export interface DownloadTemplateContext {
+  solver: BaseSolver
+  solverName: string
+  params: any
+  isPipelineSolver: boolean
+}
+
+export interface DownloadTemplateOverrides {
+  generatePageTsxContent?: (context: DownloadTemplateContext) => string
+  generateTestTsContent?: (context: DownloadTemplateContext) => string
+}
+
+export interface DownloadDropdownProps {
+  solver: BaseSolver
+  className?: string
+  overrides?: DownloadTemplateOverrides
+}
+
+export const deepRemoveUnderscoreProperties = (obj: any): any => {
+  if (obj === null || typeof obj !== "object") {
+    return obj
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map(deepRemoveUnderscoreProperties)
+  }
+
+  const result: Record<string, any> = {}
+  for (const [key, value] of Object.entries(obj)) {
+    if (!key.startsWith("_")) {
+      result[key] = deepRemoveUnderscoreProperties(value)
+    }
+  }
+  return result
+}
+
+const defaultPageTsxContent = ({
+  solverName,
+  params,
+  isPipelineSolver,
+}: DownloadTemplateContext) => {
+  const serializedParams = JSON.stringify(params, null, 2)
+
+  if (isPipelineSolver) {
+    return `import { useMemo } from "react"
+import { PipelineDebugger } from "solver-utils/lib/react"
+import { ${solverName} } from "lib/solvers/${solverName}/${solverName}"
+
+export const inputProblem = ${serializedParams}
+
+export default () => {
+  const solver = useMemo(() => new ${solverName}(inputProblem as any), [])
+  return <PipelineDebugger solver={solver} />
+}
+`
+  }
+
+  return `import { useMemo } from "react"
+import { GenericSolverDebugger } from "solver-utils/lib/react"
+import { ${solverName} } from "lib/solvers/${solverName}/${solverName}"
+
+export const inputProblem = ${serializedParams}
+
+export default () => {
+  const solver = useMemo(() => new ${solverName}(inputProblem as any), [])
+  return <GenericSolverDebugger solver={solver} />
+}
+`
+}
+
+const defaultTestTsContent = ({ solverName, params }: DownloadTemplateContext) => {
+  const serializedParams = JSON.stringify(params, null, 2)
+
+  return `import { ${solverName} } from "lib/solvers/${solverName}/${solverName}"
+import { test, expect } from "bun:test"
+
+test("${solverName} should solve problem correctly", () => {
+  const input = ${serializedParams}
+
+  const solver = new ${solverName}(input as any)
+  solver.solve()
+
+  expect(solver).toMatchSolverSnapshot(import.meta.path)
+
+  // Add more specific assertions based on expected output
+  // expect(solver.getOutput()).toMatchInlineSnapshot()
+})
+`
+}
+
+export const DownloadDropdown: React.FC<DownloadDropdownProps> = ({
+  solver,
+  className = "",
+  overrides,
+}) => {
+  const [isOpen, setIsOpen] = useState(false)
+  const dropdownRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false)
+      }
+    }
+
+    if (typeof document !== "undefined") {
+      document.addEventListener("mousedown", handleClickOutside)
+    }
+    return () => {
+      if (typeof document !== "undefined") {
+        document.removeEventListener("mousedown", handleClickOutside)
+      }
+    }
+  }, [])
+
+  const runWithParams = (
+    action: (context: DownloadTemplateContext) => void,
+  ) => {
+    if (typeof solver.getConstructorParams !== "function") {
+      const message = `getConstructorParams() is not implemented for ${solver.constructor.name}`
+      if (typeof window !== "undefined") {
+        window.alert?.(message)
+      } else {
+        console.error(message)
+      }
+      return
+    }
+
+    try {
+      const rawParams = solver.getConstructorParams()
+      const params = deepRemoveUnderscoreProperties(rawParams)
+      const solverName = solver.constructor.name
+      const context: DownloadTemplateContext = {
+        solver,
+        solverName,
+        params,
+        isPipelineSolver: solver instanceof BasePipelineSolver,
+      }
+      action(context)
+    } catch (error) {
+      const message = `Error gathering constructor params for ${solver.constructor.name}: ${error instanceof Error ? error.message : String(error)}`
+      if (typeof window !== "undefined") {
+        window.alert?.(message)
+      } else {
+        console.error(message)
+      }
+    }
+  }
+
+  const downloadJSON = () => {
+    runWithParams(({ solverName, params }) => {
+      if (typeof document === "undefined") {
+        console.error("Document is not available to trigger downloads")
+        return
+      }
+      const blob = new Blob([JSON.stringify(params, null, 2)], {
+        type: "application/json",
+      })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement("a")
+      a.href = url
+      a.download = `${solverName}_params.json`
+      a.click()
+      URL.revokeObjectURL(url)
+    })
+    setIsOpen(false)
+  }
+
+  const downloadPageTsx = () => {
+    runWithParams((context) => {
+      if (typeof document === "undefined") {
+        console.error("Document is not available to trigger downloads")
+        return
+      }
+      const content =
+        overrides?.generatePageTsxContent?.(context) ??
+        defaultPageTsxContent(context)
+      const blob = new Blob([content], { type: "text/plain" })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement("a")
+      a.href = url
+      a.download = `${context.solverName}.page.tsx`
+      a.click()
+      URL.revokeObjectURL(url)
+    })
+    setIsOpen(false)
+  }
+
+  const downloadTestTs = () => {
+    runWithParams((context) => {
+      if (typeof document === "undefined") {
+        console.error("Document is not available to trigger downloads")
+        return
+      }
+      const content =
+        overrides?.generateTestTsContent?.(context) ??
+        defaultTestTsContent(context)
+      const blob = new Blob([content], { type: "text/plain" })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement("a")
+      a.href = url
+      a.download = `${context.solverName}.test.ts`
+      a.click()
+      URL.revokeObjectURL(url)
+    })
+    setIsOpen(false)
+  }
+
+  return (
+    <div className={`relative ${className}`} ref={dropdownRef}>
+      <button
+        className="px-2 py-1 rounded text-xs cursor-pointer"
+        onClick={() => setIsOpen(!isOpen)}
+        title={`Download options for ${solver.constructor.name}`}
+        type="button"
+      >
+        {solver.constructor.name}
+      </button>
+
+      {isOpen && (
+        <div className="absolute top-full left-0 mt-1 bg-white border border-gray-300 rounded shadow-lg z-10 min-w-[150px]">
+          <button
+            className="w-full text-left px-3 py-2 hover:bg-gray-100 text-xs"
+            onClick={downloadJSON}
+            type="button"
+          >
+            Download JSON
+          </button>
+          <button
+            className="w-full text-left px-3 py-2 hover:bg-gray-100 text-xs"
+            onClick={downloadPageTsx}
+            type="button"
+          >
+            Download page.tsx
+          </button>
+          <button
+            className="w-full text-left px-3 py-2 hover:bg-gray-100 text-xs"
+            onClick={downloadTestTs}
+            type="button"
+          >
+            Download test.ts
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/lib/react/GenericSolverToolbar.tsx
+++ b/lib/react/GenericSolverToolbar.tsx
@@ -1,6 +1,8 @@
 import React, { useReducer, useRef, useEffect } from "react"
 import type { BaseSolver } from "../BaseSolver"
 import type { BasePipelineSolver } from "../BasePipelineSolver"
+import { SolverBreadcrumbInputDownloader } from "./SolverBreadcrumbInputDownloader"
+import type { DownloadTemplateOverrides } from "./DownloadDropdown"
 
 export interface GenericSolverToolbarProps {
   solver: BaseSolver
@@ -8,6 +10,7 @@ export interface GenericSolverToolbarProps {
   animationSpeed?: number
   onSolverStarted?: (solver: BaseSolver) => void
   onSolverCompleted?: (solver: BaseSolver) => void
+  downloadOverrides?: DownloadTemplateOverrides
 }
 
 export const GenericSolverToolbar = ({
@@ -16,6 +19,7 @@ export const GenericSolverToolbar = ({
   animationSpeed = 25,
   onSolverStarted,
   onSolverCompleted,
+  downloadOverrides,
 }: GenericSolverToolbarProps) => {
   const [isAnimating, setIsAnimating] = useReducer((x) => !x, false)
   const animationRef = useRef<NodeJS.Timeout | undefined>(undefined)
@@ -111,6 +115,11 @@ export const GenericSolverToolbar = ({
 
   return (
     <div className="space-y-2 p-2 border-b">
+      <SolverBreadcrumbInputDownloader
+        solver={solver}
+        overrides={downloadOverrides}
+      />
+
       <div className="flex gap-2 items-center flex-wrap">
         <button
           onClick={handleStep}

--- a/lib/react/PipelineDebugger.tsx
+++ b/lib/react/PipelineDebugger.tsx
@@ -1,30 +1,37 @@
-import React, { useEffect, useMemo, useReducer } from "react"
+import React, { useMemo, useReducer } from "react"
+import type { BasePipelineSolver } from "../BasePipelineSolver"
 import type { BaseSolver } from "../BaseSolver"
 import { InteractiveGraphics } from "graphics-debug/react"
 import { GenericSolverToolbar } from "./GenericSolverToolbar"
+import { PipelineStageTable } from "./PipelineStageTable"
 import type { DownloadTemplateOverrides } from "./DownloadDropdown"
 
-export interface GenericSolverDebuggerProps {
-  solver: BaseSolver
+export interface PipelineDebuggerProps {
+  solver: BasePipelineSolver<any>
   animationSpeed?: number
   onSolverStarted?: (solver: BaseSolver) => void
   onSolverCompleted?: (solver: BaseSolver) => void
   downloadOverrides?: DownloadTemplateOverrides
 }
 
-export const GenericSolverDebugger = ({
+export const PipelineDebugger: React.FC<PipelineDebuggerProps> = ({
   solver,
   animationSpeed = 25,
   onSolverStarted,
   onSolverCompleted,
   downloadOverrides,
-}: GenericSolverDebuggerProps) => {
+}) => {
   const [renderCount, incRenderCount] = useReducer((x) => x + 1, 0)
 
   const visualization = useMemo(() => {
     try {
       return (
-        solver.visualize() || { points: [], lines: [], rects: [], circles: [] }
+        solver.visualize() || {
+          points: [],
+          lines: [],
+          rects: [],
+          circles: [],
+        }
       )
     } catch (error) {
       console.error("Visualization error:", error)
@@ -41,19 +48,6 @@ export const GenericSolverDebugger = ({
     [visualization],
   )
 
-  useEffect(() => {
-    if (typeof document === "undefined") return
-    if (
-      !document.querySelector(
-        'script[src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"]',
-      )
-    ) {
-      const script = document.createElement("script")
-      script.src = "https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"
-      document.head.appendChild(script)
-    }
-  }, [])
-
   return (
     <div>
       <GenericSolverToolbar
@@ -69,6 +63,10 @@ export const GenericSolverDebugger = ({
       ) : (
         <InteractiveGraphics graphics={visualization} />
       )}
+      <PipelineStageTable
+        pipelineSolver={solver}
+        triggerRender={() => incRenderCount()}
+      />
     </div>
   )
 }

--- a/lib/react/PipelineStageTable.tsx
+++ b/lib/react/PipelineStageTable.tsx
@@ -1,0 +1,158 @@
+import React from "react"
+import type { BasePipelineSolver } from "../BasePipelineSolver"
+import { deepRemoveUnderscoreProperties } from "./DownloadDropdown"
+
+type StageStatus = "Solved" | "Failed" | "Running" | "Not Started"
+
+export interface PipelineStageTableProps {
+  pipelineSolver: BasePipelineSolver<any>
+  triggerRender: () => void
+}
+
+/**
+ * Displays every stage of the pipeline with the status ("Solved", "Failed", "Running" or "Not Started"),
+ * what iteration it started on, what iteration it ended on, and the time it took to solve.
+ *
+ * The table also has a column "Actions" that has a download icon to download the getConstructorParams()
+ * of each stage.
+ */
+export const PipelineStageTable: React.FC<PipelineStageTableProps> = ({
+  pipelineSolver,
+  triggerRender,
+}) => {
+  const getStageStatus = (stageIndex: number): StageStatus => {
+    if (pipelineSolver.currentPipelineStepIndex > stageIndex) {
+      return "Solved"
+    }
+    if (pipelineSolver.currentPipelineStepIndex === stageIndex) {
+      if (pipelineSolver.failed) return "Failed"
+      if (pipelineSolver.activeSubSolver) return "Running"
+    }
+    return "Not Started"
+  }
+
+  const downloadParams = (stageName: string) => {
+    const stage = pipelineSolver.pipelineDef.find(
+      (s) => s.solverName === stageName,
+    )
+    if (!stage) return
+
+    try {
+      if (typeof document === "undefined") {
+        console.error("Document is not available to download stage params")
+        return
+      }
+      const rawParams = stage.getConstructorParams(pipelineSolver)
+      const params = deepRemoveUnderscoreProperties(rawParams)
+      const blob = new Blob([JSON.stringify(params, null, 2)], {
+        type: "application/json",
+      })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement("a")
+      a.href = url
+      a.download = `${stageName}_params.json`
+      a.click()
+      URL.revokeObjectURL(url)
+    } catch (error) {
+      const message = `Error downloading params for ${stageName}: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+      if (typeof window !== "undefined") {
+        window.alert?.(message)
+      } else {
+        console.error(message)
+      }
+    }
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full border border-gray-300">
+        <thead>
+          <tr className="bg-gray-100">
+            <th className="border border-gray-300 px-4 py-2 text-left">Stage</th>
+            <th className="border border-gray-300 px-4 py-2 text-left">Status</th>
+            <th className="border border-gray-300 px-4 py-2 text-left">
+              Start Iteration
+            </th>
+            <th className="border border-gray-300 px-4 py-2 text-left">
+              End Iteration
+            </th>
+            <th className="border border-gray-300 px-4 py-2 text-left">
+              Time (ms)
+            </th>
+            <th className="border border-gray-300 px-4 py-2 text-left">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {pipelineSolver.pipelineDef.map((stage, index) => {
+            const status = getStageStatus(index)
+            const startIteration =
+              pipelineSolver.firstIterationOfPhase[stage.solverName]
+            const endIteration =
+              status === "Solved"
+                ? (pipelineSolver.firstIterationOfPhase[stage.solverName] || 0) +
+                  ((pipelineSolver as any)[stage.solverName]?.iterations || 0)
+                : undefined
+            const timeSpent = pipelineSolver.timeSpentOnPhase[stage.solverName]
+
+            return (
+              <tr key={stage.solverName} className="hover:bg-gray-50">
+                <td className="border border-gray-300 px-4 py-2 font-mono text-sm">
+                  {stage.solverName}
+                </td>
+                <td className="border border-gray-300 px-4 py-2">
+                  <div className="flex items-center gap-2">
+                    <span
+                      className={`px-2 py-1 rounded text-sm ${
+                        status === "Solved"
+                          ? "bg-green-100 text-green-800"
+                          : status === "Failed"
+                            ? "bg-red-100 text-red-800"
+                            : status === "Running"
+                              ? "bg-yellow-100 text-yellow-800"
+                              : "bg-gray-100 text-gray-800"
+                      }`}
+                    >
+                      {status}
+                    </span>
+                    <button
+                      onClick={() => {
+                        pipelineSolver.solveUntilPhase(stage.solverName)
+                        triggerRender()
+                      }}
+                      className="hover:bg-green-500 text-gray-600 hover:text-white px-2 py-1 rounded text-sm"
+                      title={`Run until ${stage.solverName} is active`}
+                      type="button"
+                    >
+                      ▶️
+                    </button>
+                  </div>
+                </td>
+                <td className="border border-gray-300 px-4 py-2 text-center">
+                  {startIteration !== undefined ? startIteration : "-"}
+                </td>
+                <td className="border border-gray-300 px-4 py-2 text-center">
+                  {endIteration !== undefined ? endIteration : "-"}
+                </td>
+                <td className="border border-gray-300 px-4 py-2 text-center">
+                  {timeSpent !== undefined ? Math.round(timeSpent) : "-"}
+                </td>
+                <td className="border border-gray-300 px-4 py-2 text-center">
+                  <button
+                    onClick={() => downloadParams(stage.solverName)}
+                    className="bg-blue-500 hover:bg-blue-600 text-white px-2 py-1 rounded text-sm"
+                    title="Download constructor params"
+                    type="button"
+                  >
+                    ⬇️
+                  </button>
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/lib/react/SolverBreadcrumbInputDownloader.tsx
+++ b/lib/react/SolverBreadcrumbInputDownloader.tsx
@@ -1,0 +1,36 @@
+import React from "react"
+import type { BaseSolver } from "../BaseSolver"
+import { DownloadDropdown, type DownloadTemplateOverrides } from "./DownloadDropdown"
+
+export const getSolverChain = (solver: BaseSolver): BaseSolver[] => {
+  if (!solver.activeSubSolver) {
+    return [solver]
+  }
+  return [solver, ...getSolverChain(solver.activeSubSolver)]
+}
+
+export interface SolverBreadcrumbInputDownloaderProps {
+  solver: BaseSolver
+  className?: string
+  overrides?: DownloadTemplateOverrides
+}
+
+/**
+ * Displays each solver in the chain as a breadcrumb with download functionality
+ */
+export const SolverBreadcrumbInputDownloader: React.FC<
+  SolverBreadcrumbInputDownloaderProps
+> = ({ solver, className = "", overrides }) => {
+  const solverChain = getSolverChain(solver)
+
+  return (
+    <div className={`flex gap-1 items-center text-sm pt-1 ${className}`}>
+      {solverChain.map((s, index) => (
+        <div key={`${s.constructor.name}-${index}`} className="flex items-center">
+          {index > 0 && <span className="text-gray-400 mx-1">→</span>}
+          <DownloadDropdown solver={s} overrides={overrides} />
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/lib/react/index.ts
+++ b/lib/react/index.ts
@@ -1,2 +1,6 @@
 export * from "./GenericSolverDebugger"
 export * from "./GenericSolverToolbar"
+export * from "./DownloadDropdown"
+export * from "./SolverBreadcrumbInputDownloader"
+export * from "./PipelineStageTable"
+export * from "./PipelineDebugger"

--- a/site/example-solver-demo.page.tsx
+++ b/site/example-solver-demo.page.tsx
@@ -11,7 +11,10 @@ import { ExampleSolver } from "./ExampleSolver"
  */
 export default function ExampleSolverDemo() {
   // Create a new instance of our example solver
-  const solver = useMemo(() => new ExampleSolver(), [])
+  const solver = useMemo(
+    () => new ExampleSolver(ExampleSolver.createDefaultParams()),
+    [],
+  )
 
   return (
     <GenericSolverDebugger

--- a/site/pipeline-solver-demo.page.tsx
+++ b/site/pipeline-solver-demo.page.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from "react"
-import { GenericSolverDebugger } from "../lib/react/GenericSolverDebugger"
+import { PipelineDebugger } from "../lib/react/PipelineDebugger"
 import { ExamplePipelineSolver } from "./ExamplePipelineSolver"
 
 /**
@@ -22,7 +22,7 @@ export default function PipelineSolverDemo() {
   )
 
   return (
-    <GenericSolverDebugger
+    <PipelineDebugger
       solver={solver}
       animationSpeed={100}
       onSolverStarted={(solver) => {
@@ -30,7 +30,9 @@ export default function PipelineSolverDemo() {
       }}
       onSolverCompleted={(solver) => {
         console.log("Pipeline solver completed:", solver)
-        console.log("Phase statistics:", (solver as any).getPhaseStats())
+        if (solver instanceof ExamplePipelineSolver) {
+          console.log("Phase statistics:", solver.getPhaseStats())
+        }
       }}
     />
   )

--- a/tests/BaseSolver.test.ts
+++ b/tests/BaseSolver.test.ts
@@ -93,7 +93,7 @@ test("BaseSolver visualization", () => {
 
 test("BaseSolver max iterations protection", () => {
   class InfiniteSolver extends BaseSolver {
-    MAX_ITERATIONS = 5
+    override MAX_ITERATIONS = 5
 
     override _step() {
       // Never set solved = true


### PR DESCRIPTION
## Summary
- add reusable download dropdown, solver breadcrumb, and pipeline debugger components with customizable templates
- update solver examples and pipeline helpers to rely on single-argument constructor inputs surfaced through getConstructorParams
- expose new React utilities and refresh tests to reflect the constructor contract changes

## Testing
- bunx tsc --noEmit
- bun test tests

------
https://chatgpt.com/codex/tasks/task_b_68cb8ee60674832e9d5443edfe395ac7