### PR TITLE
Align nested pipeline stage columns

### DIFF
--- a/lib/react/PipelineStagesTable.tsx
+++ b/lib/react/PipelineStagesTable.tsx
@@ -14,6 +14,17 @@ interface PipelineStagesTableProps {
   triggerRender?: () => void
 }
 
+const STAGE_TABLE_COLUMN_WIDTHS = [
+  "40%",
+  "11rem",
+  "5rem",
+  "7rem",
+  "12rem",
+  "7rem",
+  "20%",
+  "6rem",
+] as const
+
 /** Check if a solver is a pipeline solver (has pipelineDef) */
 const isPipelineSolver = (
   solver: BaseSolver | null,
@@ -441,7 +452,12 @@ export const PipelineStagesTable = ({
         </div>
       )}
       <div className="overflow-x-auto">
-        <table className="w-full text-sm">
+        <table className="w-full table-fixed text-sm">
+          <colgroup>
+            {STAGE_TABLE_COLUMN_WIDTHS.map((width, index) => (
+              <col key={index} style={{ width }} />
+            ))}
+          </colgroup>
           {!isNested && (
             <thead>
               <tr className="bg-gray-50 border-b border-gray-200">


### PR DESCRIPTION
### Motivation
- Nested/expanded pipeline rows caused non-name columns to shift; the change ensures only the solver-name column is indented while other columns remain aligned.

### Description
- Add a shared column width definition `STAGE_TABLE_COLUMN_WIDTHS` and apply it with a `colgroup` on the table and `table-fixed` layout so parent and nested tables use identical column sizing.

### Testing
- Ran `bun run format` which completed successfully.
- Ran `bunx tsc --noEmit` for typechecking which succeeded.
- Ran `bun test tests/PipelineStagesTable.test.ts` which passed (3 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c1c4eb5e80832ea6bbd291939377d8)