### PR TITLE
Add Reset button to debugger toolbar after solver completion

### DIFF
--- a/lib/react/GenericSolverDebugger.tsx
+++ b/lib/react/GenericSolverDebugger.tsx
@@ -48,7 +48,7 @@ export const GenericSolverDebugger = ({
   onSolverCompleted,
 }: GenericSolverDebuggerProps) => {
   const [renderCount, incRenderCount] = useReducer((x) => x + 1, 0)
-  const [solver] = useState<BaseSolver>(() => {
+  const [solver, setSolver] = useState<BaseSolver>(() => {
     if (createSolver) {
       return createSolver()
     }
@@ -142,6 +142,30 @@ export const GenericSolverDebugger = ({
     }
   }
 
+  const handleSolverReset = () => {
+    if (createSolver) {
+      setSolver(createSolver())
+      incRenderCount()
+      return
+    }
+
+    try {
+      const constructorParams = solver.getConstructorParams()
+      const constructorArgs = Array.isArray(constructorParams)
+        ? constructorParams
+        : []
+      const nextSolver = new (
+        solver.constructor as new (
+          ...args: any[]
+        ) => BaseSolver
+      )(...constructorArgs)
+      setSolver(nextSolver)
+      incRenderCount()
+    } catch (error) {
+      console.warn(`Could not reset solver ${solver.getSolverName()}:`, error)
+    }
+  }
+
   return (
     <div>
       <GenericSolverToolbar
@@ -154,6 +178,7 @@ export const GenericSolverDebugger = ({
         onDownloadVisualization={handleDownloadVisualization}
         onSolverStarted={onSolverStarted}
         onSolverCompleted={onSolverCompleted}
+        onSolverReset={handleSolverReset}
       />
       {graphicsAreEmpty ? (
         <div className="p-4 text-gray-500">No Graphics Yet</div>

--- a/lib/react/GenericSolverToolbar.tsx
+++ b/lib/react/GenericSolverToolbar.tsx
@@ -15,6 +15,7 @@ export interface GenericSolverToolbarProps {
   onDownloadVisualization: () => void
   onSolverStarted?: (solver: BaseSolver) => void
   onSolverCompleted?: (solver: BaseSolver) => void
+  onSolverReset?: () => void
 }
 
 export const GenericSolverToolbar = ({
@@ -27,6 +28,7 @@ export const GenericSolverToolbar = ({
   onDownloadVisualization,
   onSolverStarted,
   onSolverCompleted,
+  onSolverReset,
 }: GenericSolverToolbarProps) => {
   const [isAnimating, setIsAnimating] = useReducer((x) => !x, false)
   const animationRef = useRef<NodeJS.Timeout | undefined>(undefined)
@@ -317,13 +319,23 @@ export const GenericSolverToolbar = ({
           Step
         </button>
 
-        <button
-          onClick={handleSolve}
-          disabled={solver.solved || solver.failed || isAnimating}
-          className="rounded bg-green-500 px-3 py-1 text-sm text-white hover:bg-green-600 disabled:bg-gray-300"
-        >
-          Solve
-        </button>
+        {solver.solved || solver.failed ? (
+          <button
+            onClick={onSolverReset}
+            disabled={!onSolverReset || isAnimating}
+            className="rounded bg-purple-500 px-3 py-1 text-sm text-white hover:bg-purple-600 disabled:bg-gray-300"
+          >
+            Reset
+          </button>
+        ) : (
+          <button
+            onClick={handleSolve}
+            disabled={isAnimating}
+            className="rounded bg-green-500 px-3 py-1 text-sm text-white hover:bg-green-600 disabled:bg-gray-300"
+          >
+            Solve
+          </button>
+        )}
 
         <button
           onClick={handleAnimate}


### PR DESCRIPTION
### Motivation
- Allow users to reset a solver from the debugger UI after it reaches a terminal state (`solved` or `failed`) instead of leaving the `Solve` button disabled. 
- Provide a simple programmatic hook for reset behavior so the debugger can create a fresh solver instance and re-render the UI.

### Description
- Added an optional `onSolverReset?: () => void` prop to `GenericSolverToolbar` and replaced the toolbar's `Solve` button with a `Reset` button when `solver.solved || solver.failed`. 
- Wired a `handleSolverReset` in `GenericSolverDebugger` and passed it to the toolbar; the handler prefers `createSolver()` when provided and otherwise attempts to reconstruct a new solver using the current solver constructor and `getConstructorParams()`. 
- Converted the debugger's `solver` to state (`useState`) so it can be replaced with `setSolver(...)`, and call `incRenderCount()` to trigger a re-render after reset. 
- Defensive TypeScript fix: normalize `getConstructorParams()` result to an array before spreading into the constructor to avoid iterator errors.

### Testing
- Ran unit tests with `bun test tests` and all tests passed (`22 pass, 0 fail`).
- Typechecked with `bunx tsc --noEmit` which succeeded with no errors.
- Ran code formatting with `bun run format` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d7025d4334832ea312c648580a4fc6)