### PR TITLE
Render solver lines with round joins

### DIFF
--- a/lib/react/SimpleGraphicsSVG.tsx
+++ b/lib/react/SimpleGraphicsSVG.tsx
@@ -89,6 +89,7 @@ export function SimpleGraphicsSVG({ graphics }: { graphics: GraphicsObject }) {
           fill="none"
           stroke={l.strokeColor ?? "black"}
           strokeWidth={l.strokeWidth ?? 1}
+          strokeLinejoin="round"
           points={(l.points ?? [])
             .map((p: any) => `${p.x ?? 0},${p.y ?? 0}`)
             .join(" ")}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@react-hook/resize-observer": "^2.0.2",
     "@types/bun": "latest",
     "@types/react": "^19.1.13",
-    "graphics-debug": "^0.0.76",
+    "graphics-debug": "0.0.99",
     "react": "^19.1.1",
     "react-cosmos": "^7.0.0",
     "react-cosmos-plugin-vite": "^7.0.0",


### PR DESCRIPTION
## Summary

- update the development renderer dependency to `graphics-debug@0.0.99`
- render lines in `SimpleGraphicsSVG` with rounded joins

## Why

`graphics-debug@0.0.99` makes generated SVG, Canvas, and PNG line joins round. `solver-utils` also has a fallback SVG renderer that emits its own polylines, so it needs the same explicit join style to keep solver visualizations consistent.

Upstream: tscircuit/graphics-debug#229

## Validation

- `bunx tsc --noEmit`
- `bun run build`
- `bun run format:check`
- `git diff --check`